### PR TITLE
Backwards compatible naming resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ COURSES = [
 2. You have two methods to add courses:
 a. New way: Just add them via LinkedIn (app or browser) to your bookmarks. The tool will parse your LinkedIn bookmarks (https://www.linkedin.com/learning/me/saved) at runtime.
 
-2. Old way: Fill the `COURSES` array with the slug of the the courses you want to download and save the config file, for example:
+b. Old way: Fill the `COURSES` array with the slug of the the courses you want to download and save the config file, for example:
 `https://www.linkedin.com/learning/it-security-foundations-core-concepts/ -> it-security-foundations-core-concepts`
 
 The app will add parsed bookmark-courses to the config file after checking for duplicates before.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ First install the requirements:
 ```
 pip install -r requirements.txt
 ```
-In the `config.py` file, write your login info and fill the `COURSES` array with the slug of the the courses you want to download, for example:
+In the `config.py` file, write your login info, download path and fill the `COURSES` array with the slug of the the courses you want to download, for example:
 
 `https://www.linkedin.com/learning/it-security-foundations-core-concepts/ -> it-security-foundations-core-concepts`
 
 ```
 USERNAME = 'user@email.com'
 PASSWORD = 'password'
+BASE_DOWNLOAD_PATH = 'E:/Downloads/LinkedInLearning' #use "/" as separators
 
 COURSES = [
     'it-security-foundations-core-concepts',
@@ -29,9 +30,9 @@ Then execute the script:
 ```
 python lld.py
 ```
-The courses will be saved in the `out` folder.
+The courses will be saved in your defined download folder.
 
-### Demo
+### Demo (Outdated by now)
 [![asciicast](https://asciinema.org/a/143894.png)](https://asciinema.org/a/143894)
 
 ---

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Features:
 * Downloading complete courses, i.e. course description inkl. original course url, videos, exercise files, subtitles.
 * Easy adding of courses to download list
 * Skipping existing downloads and completing incomplete courses.
+* Backwards compatible with previous folder structure and naming convention
+    * Use it to complete previous downloads and change the naming of folder and files.
 * Unchecking of successfully downloaded courses on your download list, therefore providing some kind of archive.
 * Numbering of chapters, videos and subtitles.
 * Subtitles will have the same name as the video file, so players like MPC-HC will automatically load the subtitles when playing a video file.

--- a/README.md
+++ b/README.md
@@ -5,17 +5,22 @@
 [![built with Python2.7](https://img.shields.io/badge/built%20with-Python2.7-red.svg?style=flat-square)](https://www.python.org/)
 
 ### A scraping tool that downloads video lessons from Linkedin Learning
-Implemented in python using requests
+Features:
+-Implemented in python using requests.
+-Downloading complete courses, i.e. course description inkl. original course url, videos, exercise files, subtitles.
+-Easy adding of courses to download list
+-Skipping existing downloads and completing incomplete courses.
+-Unchecking of successfully downloaded courses on your download list, therefore providing some kind of archive.
+-Numbering of chapters, videos and subtitles.
+-Subtitles will have the same name as the video file, so players like MPC-HC will automatically load the subtitles when playing a video file.
+-Course folder includes release date, because courses sometimes get updated and you don't know which version you already downloaded.
 
 ### How to use
 First install the requirements:
 ```
 pip install -r requirements.txt
 ```
-In the `config.py` file, write your login info, download path and fill the `COURSES` array with the slug of the the courses you want to download, for example:
-
-`https://www.linkedin.com/learning/it-security-foundations-core-concepts/ -> it-security-foundations-core-concepts`
-
+The `config.py` looks like this:
 ```
 USERNAME = 'user@email.com'
 PASSWORD = 'password'
@@ -26,13 +31,31 @@ COURSES = [
     'javascript-for-web-designers-2'
 ]
 ```
+1. Enter your login info and download path.
+
+2. You have two methods to add courses:
+a. New way: Just add them via LinkedIn (app or browser) to your bookmarks. The tool will parse your LinkedIn bookmarks (https://www.linkedin.com/learning/me/saved) at runtime.
+
+2. Old way: Fill the `COURSES` array with the slug of the the courses you want to download and save the config file, for example:
+`https://www.linkedin.com/learning/it-security-foundations-core-concepts/ -> it-security-foundations-core-concepts`
+
+The app will add parsed bookmark-courses to the config file after checking for duplicates before.
+You use both methods parallel. 
+
+Skipping existing downloads: 
+If you already downloaded a course, the app will check the Download Path for existence of each to-be-downloaded-course and all subfolder and files, thus excluding duplicates. Files (couse-videos, exercise files, subtitles or course descriptions) which do not exist will be downloaded and therefore complete an unfinished course.
+
+Unchecking downloaded courses: 
+After successfully downloading a course, the course will be disabled in the config file (Download list) by putting a "#" in front of the course. If you want to check courses for integrity again, just remove the "#" and the next time when running the app it will check the enabled courses (see above).
+
+
 Then execute the script:
 ```
 python lld.py
 ```
 The courses will be saved in your defined download folder.
 
-### Demo (Outdated by now)
+### Demo (outdated by now)
 [![asciicast](https://asciinema.org/a/143894.png)](https://asciinema.org/a/143894)
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,21 +6,14 @@
 
 ### A scraping tool that downloads video lessons from Linkedin Learning
 Features:
--Implemented in python using requests.
-
--Downloading complete courses, i.e. course description inkl. original course url, videos, exercise files, subtitles.
-
--Easy adding of courses to download list
-
--Skipping existing downloads and completing incomplete courses.
-
--Unchecking of successfully downloaded courses on your download list, therefore providing some kind of archive.
-
--Numbering of chapters, videos and subtitles.
-
--Subtitles will have the same name as the video file, so players like MPC-HC will automatically load the subtitles when playing a video file.
-
--Course folder includes release date, because courses sometimes get updated and you don't know which version you already downloaded.
+* Implemented in python using requests.
+* Downloading complete courses, i.e. course description inkl. original course url, videos, exercise files, subtitles.
+* Easy adding of courses to download list
+* Skipping existing downloads and completing incomplete courses.
+* Unchecking of successfully downloaded courses on your download list, therefore providing some kind of archive.
+* Numbering of chapters, videos and subtitles.
+* Subtitles will have the same name as the video file, so players like MPC-HC will automatically load the subtitles when playing a video file.
+* Course folder includes release date, because courses sometimes get updated and you don't know which version you already downloaded.
 
 ### How to use
 First install the requirements:
@@ -41,7 +34,7 @@ COURSES = [
 
 1. Enter your login info and download path.
 
-2. You have two methods to add courses:
+2. You have two ways to add courses:
 
    a. New way: Just add them via LinkedIn (app or browser) to your bookmarks. The tool will parse your LinkedIn bookmarks (https://www.linkedin.com/learning/me/saved) at runtime.
 
@@ -51,10 +44,10 @@ COURSES = [
 The app will add the parsed bookmarks to the config file after checking for duplicates.
 You use both methods parallel. 
 
-Skipping existing downloads: 
+*Skipping existing downloads:* 
 If you already downloaded a course, the app will check the Download Path for existence of each to-be-downloaded-course and all subfolder and files, thus excluding duplicates. Files (couse-videos, exercise files, subtitles or course descriptions) which do not exist will be downloaded and therefore complete an unfinished course.
 
-Unchecking downloaded courses: 
+*Unchecking downloaded courses:*
 After successfully downloading a course, the course will be disabled in the config file (Download list) by putting a "#" in front of the course. If you want to check courses for integrity again, just remove the "#" and the next time when running the app it will check the enabled courses (see above).
 
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,19 @@
 ### A scraping tool that downloads video lessons from Linkedin Learning
 Features:
 -Implemented in python using requests.
+
 -Downloading complete courses, i.e. course description inkl. original course url, videos, exercise files, subtitles.
+
 -Easy adding of courses to download list
+
 -Skipping existing downloads and completing incomplete courses.
+
 -Unchecking of successfully downloaded courses on your download list, therefore providing some kind of archive.
+
 -Numbering of chapters, videos and subtitles.
+
 -Subtitles will have the same name as the video file, so players like MPC-HC will automatically load the subtitles when playing a video file.
+
 -Course folder includes release date, because courses sometimes get updated and you don't know which version you already downloaded.
 
 ### How to use

--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ COURSES = [
 1. Enter your login info and download path.
 
 2. You have two methods to add courses:
-a. New way: Just add them via LinkedIn (app or browser) to your bookmarks. The tool will parse your LinkedIn bookmarks (https://www.linkedin.com/learning/me/saved) at runtime.
 
-b. Old way: Fill the `COURSES` array with the slug of the the courses you want to download and save the config file, for example:
+   a. New way: Just add them via LinkedIn (app or browser) to your bookmarks. The tool will parse your LinkedIn bookmarks (https://www.linkedin.com/learning/me/saved) at runtime.
+
+   b. Old way: Fill the `COURSES` array with the slug of the the courses you want to download and save the config file, for example:
 `https://www.linkedin.com/learning/it-security-foundations-core-concepts/ -> it-security-foundations-core-concepts`
 
-The app will add parsed bookmark-courses to the config file after checking for duplicates before.
+The app will add the parsed bookmarks to the config file after checking for duplicates.
 You use both methods parallel. 
 
 Skipping existing downloads: 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ COURSES = [
     'javascript-for-web-designers-2'
 ]
 ```
+
 1. Enter your login info and download path.
 
 2. You have two methods to add courses:

--- a/config.py
+++ b/config.py
@@ -2,6 +2,7 @@
 
 USERNAME = ''
 PASSWORD = ''
+BASE_DOWNLOAD_PATH = 'E:/Downloads/LinkedInLearning' #use "/" as separators
 
 COURSES = [
     'it-security-foundations-core-concepts',

--- a/lld.py
+++ b/lld.py
@@ -179,6 +179,9 @@ if __name__ == '__main__':
         #print 'Course-URL: "%s"' % course_api_url
         r = requests.get(course_api_url, cookies=cookies, headers=headers)
         #print 'Response from Server: %s' % r        
+        if r.json()['status'] == 404:
+            print('[!] Server-Reponse: 404. Mostly caused by user failure when providing a wrong course slug in config file.\n[!] Check for errors like: course-title-xyz/setting-up-the-abc. Only course slug is allowed.')
+            exit(0);
         course_title = cleanup_string(r.json()['elements'][0]['title'])
         course_description = r.json()['elements'][0]['description']
         fullCourseUnlocked = r.json()['elements'][0]['fullCourseUnlocked']

--- a/lld.py
+++ b/lld.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import cookielib
 import os
 import urllib
@@ -7,6 +6,8 @@ import sys
 import config
 import requests
 import re
+import time
+import datetime
 from bs4 import BeautifulSoup
 
 reload(sys)
@@ -78,6 +79,37 @@ def download_file(url, file_path, file_name):
         for chunk in reply.iter_content(chunk_size=1024):
             if chunk:
                 f.write(chunk)
+                
+def to_hhmmssms(ms):
+    sec,ms = divmod(ms,1000)
+    min,sec = divmod(sec,60)
+    hr,min = divmod(min,60)
+    return "%d:%02d:%02d.%03d" % (hr,min,sec,ms)
+    
+    
+def download_subtitles(course_name,course_releasedate,index,chapter_name, vc, video_name):
+    #srt needs start and end time, while LinkedIn is only providing start time. So I use end-time of a subtitle = start time of the next subtitle.
+    with open('out/%s (%s)/%s - %s/%s - %s.srt' % (course_name,course_releasedate,str(index),chapter_name, vc, video_name), 'a') as subtitle_file:
+        index_next_subtitle = 1
+        for subtitle in subtitles:                   
+            #print('Next-Index: "%i"') % index_next_subtitle
+            transcriptStartAt = milliseconds=subtitle['transcriptStartAt']                            
+            #for last subtitle (which hasn't a successor) use an end time that is probably longer than the video has now left (+5 seconds)
+            if (index_next_subtitle == len(subtitles)): #detecting list index out of boundary
+                transcriptEndAt = transcriptStartAt + 5000
+            else:
+                transcriptEndAt = milliseconds=subtitles[index_next_subtitle]['transcriptStartAt']            
+            caption = subtitle['caption']            
+            subtitle_file.write(str(index_next_subtitle))
+            subtitle_file.write('\n')
+            subtitle_file.write(str(to_hhmmssms(transcriptStartAt)))
+            subtitle_file.write(' --> ')
+            subtitle_file.write(str(to_hhmmssms(transcriptEndAt)))
+            subtitle_file.write('\n')
+            subtitle_file.write(caption)
+            subtitle_file.write('\n \n')       
+            index_next_subtitle+=1                        
+    subtitle_file.close()
 
 
 if __name__ == '__main__':
@@ -86,34 +118,50 @@ if __name__ == '__main__':
     cookies['JSESSIONID'] = 'ajax:4332914976342601831'
     for course in config.COURSES:
         print ''
+        #request release-time field of course
         course_url = 'https://www.linkedin.com/learning-api/detailedCourses' \
-                     '??fields=videos&addParagraphsToTranscript=true&courseSlug={0}&q=slugs'.format(course)
+                     '??fields=releasedOn&addParagraphsToTranscript=true&courseSlug={0}&q=slugs'.format(course)
+        #print 'Course-URL: "%s"' % course_url
         r = requests.get(course_url, cookies=cookies, headers=headers)
-        invalid_file_chars = r'[\\/*?:.,"\'<>|]'
+        #print 'Response from Server: %s' % r
         course_name = r.json()['elements'][0]['title']
-        course_name = re.sub(invalid_file_chars, " ", course_name).strip().encode('utf-8')
+        
+        invalid_file_chars = r'[^A-Za-z0-9 ]+'
         chapters = r.json()['elements'][0]['chapters']
+        course_name = re.sub(invalid_file_chars, " ", course_name)
+        course_releasedate_unix = r.json()['elements'][0]['releasedOn']
+        course_releasedate = time.strftime("%Y-%m-%d", time.gmtime(course_releasedate_unix / 1000.0))
+        #for future use: tag/name of updated-element unknown on LinkedIn Learning so far. If known, use the newer Update date for course-folder instead of old initial release date
+        #course_updatedate_unix = 
+        #course_releasedate
         print '[*] Parsing "%s" course\'s chapters' % course_name
         print '[*] [%d chapters found]' % len(chapters)
+        index = 0
         for chapter in chapters:
-            chapter_name = re.sub(invalid_file_chars, " ", chapter['title']).strip().encode('utf-8')
+            # chapter_name = re.sub(invalid_file_chars, " ", chapter['title'])
+            chapter_name = re.sub(r'[\\/*?:"<>|]', "", chapter['title'])
             videos = chapter['videos']
             vc = 0
+            index +=1
             print '[*] --- Parsing "%s" chapters\'s videos' % chapter_name
             print '[*] --- [%d videos found]' % len(videos)
             for video in videos:
-                video_name = re.sub(invalid_file_chars, " ", video['title']).strip().encode('utf-8')
+                video_name = re.sub(invalid_file_chars, " ", video['title'])
                 video_slug = video['slug']
                 video_url = 'https://www.linkedin.com/learning-api/detailedCourses' \
                             '?addParagraphsToTranscript=false&courseSlug={0}&q=slugs&resolution=_720&videoSlug={1}'\
                     .format(course, video_slug)
-                r = requests.get(video_url, cookies=cookies, headers=headers)
+                r = requests.get(video_url, cookies=cookies, headers=headers)                
+                subtitles = r.json()['elements'][0]['selectedVideo']['transcript']['lines']
                 vc += 1
                 try:
                     download_url = re.search('"progressiveUrl":"(.+)","streamingUrl"', r.text).group(1)
+                    #print 'Searching-URL: "%s"' % download_url
                 except:
                     print '[!] ------ Can\'t download the video "%s", probably is only for premium users' % video_name
                 else:
                     print '[*] ------ Downloading video "%s"' % video_name
-                    download_file(download_url, 'out/%s/%s' % (course_name, chapter_name), '%s. %s.mp4' %
-                                  (str(vc), video_name))
+                    #print 'Video-URL: "%s"' % download_url
+                    download_file(download_url, 'out/%s (%s)/%s - %s' % (course_name,course_releasedate,str(index),chapter_name), '%s - %s.mp4' % (str(vc), video_name))
+                    print '[*] ------ Downloading subtitles "%s"' % video_name
+                    download_subtitles(course_name,course_releasedate,index,chapter_name, vc, video_name)

--- a/lld.py
+++ b/lld.py
@@ -173,10 +173,10 @@ def parse_bookmarks():
         for course in course_elements:
             course_slug = course['content']['com.linkedin.learning.api.ListedCourse']['slug']
             for line in prev_contents:                
-                if course_slug in line: #do nothing, go to searching for next course-slug (outer loop)
+                if course_slug in line: #do nothing, go searching for next course-slug (outer loop)
                     break
-            else:   #else-after-forloop: if course-slug not found in any line/iteration, add zjis course-slug
-                prev_contents.insert(len(prev_contents)-1, "    '" + course_slug + "',\n") #Now prev_contents is a list of strings and you may add the new line to this list at any position
+            else:   #else-after-forloop: if course-slug not found in any line/iteration, add this course-slug
+                prev_contents.insert(len(prev_contents)-1, "    '" + course_slug + "',\n")
         config_file_new.writelines(prev_contents)
     #reload edited config file
     reload(config)

--- a/lld.py
+++ b/lld.py
@@ -168,7 +168,7 @@ if __name__ == '__main__':
     base_download_path = config.BASE_DOWNLOAD_PATH
     file_type_video = '.mp4'
     file_type_srt = '.srt'
-    file_type_exercise = '.zip'
+    #file_type_exercise = '.zip' #no need for that, extracted filename already contains the filetype
     file_type_description = '.txt'
     #Courses
     for course in config.COURSES:
@@ -203,7 +203,7 @@ if __name__ == '__main__':
                 continue        
             #Download course description
             if os.path.exists(course_folder_path + '/' + 'Description' + file_type_description):
-                    print '[!] Description file: already existing'                    
+                    print '[!] Description file: already existing.\n'                    
             else:
                 print ('[*] Course description: downloading...')
                 download_description(course_folder_path, 'Description' + file_type_description, course_description, 'https://www.linkedin.com/learning/' + course)
@@ -214,13 +214,13 @@ if __name__ == '__main__':
                 exercise_file_url = r.json()['elements'][0]['exerciseFiles'][0]['url']
                 exercise_size = (r.json()['elements'][0]['exerciseFiles'][0]['sizeInBytes'])/1024/1024
             except:
-                print('[!] Exercise files: not available for this course\n')
-            else:
-                print ('[*] Exercise files (%s MB): downloading...' % exercise_size)
-                if os.path.exists(course_folder_path + '/' + exercise_file_name + file_type_exercise):
-                    print '[!]          ->exercise file already existing'                    
+                print('[!] Exercise files: not available for this course.\n')
+            else:                
+                if os.path.exists(course_folder_path + '/' + exercise_file_name):
+                    print '[!] Exercise file: already existing.\n'
                 else:
-                    download_file(exercise_file_url, course_folder_path, exercise_file_name + file_type_exercise)
+                    print ('[*] Exercise file (%s MB): downloading...' % exercise_size)
+                    download_file(exercise_file_url, course_folder_path, exercise_file_name)                    
                     print('[*] --- finished.\n')
             #Chapters
             chapters = r.json()['elements'][0]['chapters']

--- a/lld.py
+++ b/lld.py
@@ -48,9 +48,10 @@ def authenticate():
         session = login()
         if len(session) == 0:
             sys.exit('[!] Unable to login to LinkedIn.com')
-        print '[*] Obtained new session: %s' % session
+        print ('[*] Obtained new session: %s' % session)
         cookies = dict(li_at=session)
-    except Exception, e:
+    except Exception as e:
+        print(e)
         sys.exit('[!] Could not authenticate to linkedin. %s' % e)
     return cookies
 
@@ -59,7 +60,7 @@ def load_page(opener, url, data=None):
     try:
         response = opener.open(url)
     except:
-        print '[Fatal] Your IP may have been temporarily blocked'
+        print ('[Fatal] Your IP may have been temporarily blocked')
     try:
         if data is not None:
             response = opener.open(url, data)
@@ -67,24 +68,25 @@ def load_page(opener, url, data=None):
             response = opener.open(url)
         return ''.join(response.readlines())
     except:
-        print '[Notice] Exception hit'
+        print ('[Notice] Exception hit')
         sys.exit(0)
 
 def cleanup_string(string):
-    umlautDictionary = {u'Ä': 'Ae',
+    replacementDictionary = {u'Ä': 'Ae',
                         u'Ö': 'Oe',
                         u'Ü': 'Ue',
                         u'ä': 'ae',
                         u'ö': 'oe',
-                        u'ü': 'ue'
+                        u'ü': 'ue',
+                        ':': ' -'                      
                         }
-    invalid_file_chars = r'[^A-Za-z0-9 ]+'
+    invalid_file_chars = r'[^A-Za-z0-9-]+'
     
     #replace Umlaut first
-    umap = {ord(key):unicode(val) for key, val in umlautDictionary.items()}
+    umap = {ord(key):unicode(val) for key, val in replacementDictionary.items()}
     string = string.translate(umap)
     #then replace other forbidden chars
-    string = re.sub(invalid_file_chars, " ", string)    
+    string = re.sub(invalid_file_chars, " ", string).strip().encode('utf-8')
     return string    
     
 
@@ -93,10 +95,16 @@ def download_file(url, file_path, file_name):
     reply = requests.get(url, stream=True)
     if not os.path.exists(file_path):
         os.makedirs(file_path)
-    with open(file_path + '/' + file_name, 'wb') as f:
-        for chunk in reply.iter_content(chunk_size=1024):
-            if chunk:
-                f.write(chunk)
+    #print(file_path + '/' + file_name)    
+    try:
+        with open(file_path + '/' + file_name, 'wb') as f:
+            for chunk in reply.iter_content(chunk_size=1024):
+                if chunk:
+                    f.write(chunk)    
+    except EnvironmentError:
+        print 'IO error. Deleting last incomplete file. Also check last created file manually for integrity'
+        os.remove(file_path + '/' + file_name)     
+
                 
 def to_hhmmssms(ms):
     sec,ms = divmod(ms,1000)
@@ -105,29 +113,34 @@ def to_hhmmssms(ms):
     return "%d:%02d:%02d.%03d" % (hr,min,sec,ms)
     
     
-def download_subtitles(course_name,course_releasedate,chapter_index,chapter_name, vc, video_name):
+def download_subtitles(filepath_and_name):
     #srt needs start and end time, while LinkedIn is only providing start time. So I use end-time of a subtitle = start time of the next subtitle.
-    with open('out/%s (%s)/%s - %s/%s - %s.srt' % (course_name,course_releasedate,str(chapter_index),chapter_name, vc, video_name), 'a') as subtitle_file:
-        index_next_subtitle = 1
-        for subtitle in subtitles:                   
-            #print('Next-Index: "%i"') % index_next_subtitle
-            transcriptStartAt = milliseconds=subtitle['transcriptStartAt']                            
-            #for last subtitle (which hasn't a successor) use an end time that is probably longer than the video has now left (+5 seconds)
-            if (index_next_subtitle == len(subtitles)): #detecting list index out of boundary
-                transcriptEndAt = transcriptStartAt + 5000
-            else:
-                transcriptEndAt = milliseconds=subtitles[index_next_subtitle]['transcriptStartAt']            
-            caption = subtitle['caption']            
-            subtitle_file.write(str(index_next_subtitle))
-            subtitle_file.write('\n')
-            subtitle_file.write(str(to_hhmmssms(transcriptStartAt)))
-            subtitle_file.write(' --> ')
-            subtitle_file.write(str(to_hhmmssms(transcriptEndAt)))
-            subtitle_file.write('\n')
-            subtitle_file.write(caption)
-            subtitle_file.write('\n \n')       
-            index_next_subtitle+=1                        
-    subtitle_file.close()
+    try:
+        with open(filepath_and_name, 'a') as subtitle_file:
+            index_next_subtitle = 1
+            for subtitle in subtitles:                   
+                #print('Next-Index: "%i"') % index_next_subtitle
+                transcriptStartAt = milliseconds=subtitle['transcriptStartAt']                            
+                #for last subtitle (which hasn't a successor) use an end time that is probably longer than the video has now left (+5 seconds)
+                if (index_next_subtitle == len(subtitles)): #detecting list index out of boundary
+                    transcriptEndAt = transcriptStartAt + 5000
+                else:
+                    transcriptEndAt = milliseconds=subtitles[index_next_subtitle]['transcriptStartAt']            
+                caption = subtitle['caption']            
+                subtitle_file.write(str(index_next_subtitle))
+                subtitle_file.write('\n')
+                subtitle_file.write(str(to_hhmmssms(transcriptStartAt)))
+                subtitle_file.write(' --> ')
+                subtitle_file.write(str(to_hhmmssms(transcriptEndAt)))
+                subtitle_file.write('\n')
+                subtitle_file.write(caption)
+                subtitle_file.write('\n \n')       
+                index_next_subtitle+=1                        
+        subtitle_file.close()
+        
+    except EnvironmentError:
+        print 'IO error. Deleting last incomplete file. Also check last created file manually for integrity'
+        os.remove(filepath_and_name)     
 
 
 if __name__ == '__main__':
@@ -135,33 +148,36 @@ if __name__ == '__main__':
     headers = {'Csrf-Token': 'ajax:4332914976342601831'}
     cookies['JSESSIONID'] = 'ajax:4332914976342601831'
     for course in config.COURSES:
-        print ''
+        print('\n')
         #request release-time field of course
         course_url = 'https://www.linkedin.com/learning-api/detailedCourses' \
                      '??fields=releasedOn&addParagraphsToTranscript=true&courseSlug={0}&q=slugs'.format(course)
         #print 'Course-URL: "%s"' % course_url
         r = requests.get(course_url, cookies=cookies, headers=headers)
         #print 'Response from Server: %s' % r
-        course_name = cleanup_string(r.json()['elements'][0]['title'])        
+        course_name = cleanup_string(r.json()['elements'][0]['title'])
         #invalid_file_chars = r'[^A-Za-z0-9 ]+'
         #course_name = re.sub(invalid_file_chars, " ", course_name)
+        print '[*] __________ Starting download of course "%s" __________' % course_name
         course_releasedate_unix = r.json()['elements'][0]['releasedOn']
         course_releasedate = time.strftime("%Y-%m-%d", time.gmtime(course_releasedate_unix / 1000.0))
         #for future use: tag/name of updated-element unknown on LinkedIn Learning so far. If known, use the newer Update date for course-folder instead of old initial release date
         #course_updatedate_unix = 
         #course_releasedate
         chapters = r.json()['elements'][0]['chapters']
-        print '[*] Parsing "%s" course\'s chapters' % course_name
-        print '[*] [%d chapters found]' % len(chapters)
+        print ('[*] Parsing course\'s chapters')
+        print ('[*] [%d chapters found]' % len(chapters))
         chapter_index = 0
         for chapter in chapters:
+            print("")
+            chapter_name = cleanup_string(chapter['title'])  
             # chapter_name = re.sub(invalid_file_chars, " ", chapter['title'])
-            chapter_name = re.sub(r'[\\/*?:"<>|]', "", chapter['title'])
+            #chapter_name = re.sub(r'[\\/*?:"<>|]', "", chapter['title'])
             videos = chapter['videos']
-            vc = 0
+            video_index = 0
             chapter_index +=1
-            print '[*] --- Parsing "%s" chapters\'s videos' % chapter_name
-            print '[*] --- [%d videos found]' % len(videos)
+            print ('[*] --- Parsing chapter #%s "%s" for videos') % (str(chapter_index), chapter_name)
+            print ('[*] --- [%d videos found]' % len(videos))
             for video in videos:
                 video_name = cleanup_string (video['title'])
                 #video_name = re.sub(invalid_file_chars, " ", video['title'])
@@ -170,21 +186,34 @@ if __name__ == '__main__':
                             '?addParagraphsToTranscript=false&courseSlug={0}&q=slugs&resolution=_720&videoSlug={1}'\
                     .format(course, video_slug)
                 r = requests.get(video_url, cookies=cookies, headers=headers)                
-                vc += 1
+                video_index += 1
                 try:
-                    download_url = re.search('"progressiveUrl":"(.+)","streamingUrl"', r.text).group(1)                    
+                    download_url = re.search('"progressiveUrl":"(.+)","streamingUrl"', r.text).group(1)
                     #print 'Searching-URL: "%s"' % download_url
                 except:
-                    print '[!] ------ Can\'t download the video "%s", probably is only for premium users' % video_name
+                    print ('[!] ------ Can\'t download the video "%s", probably is only for premium users' % video_name)
                 else:
-                    print '[*] ------ Downloading video "%s"' % video_name
-                    #print 'Video-URL: "%s"' % download_url
-                    download_file(download_url, 'out/%s (%s)/%s - %s' % (course_name,course_releasedate,str(chapter_index),chapter_name), '%s - %s.mp4' % (str(vc), video_name))
+                    file_path = 'out/%s (%s)/%s - %s' % (course_name,course_releasedate,str(chapter_index),chapter_name)
+                    file_name = '%s - %s' % (str(video_index), video_name)
+                    file_type_video = '.mp4'
+                    print ('[*] ------ Downloading video #%s "%s"' % (str(video_index), video_name))
+                    if os.path.exists(file_path + '/' + file_name + file_type_video):
+                        print '[!]          ->video file already present, now checking subtitle existence'                    
+                    else:
+                        #print 'Video-URL: "%s"' % download_url
+                        download_file(download_url, file_path, file_name + file_type_video)
                 try:
                     subtitles = r.json()['elements'][0]['selectedVideo']['transcript']['lines']
                 except:
-                    print '[*] ------- No subtitles available'
+                    print('[*] ------ No subtitles available')
                 else:
-                    print '[*] ------- Downloading subtitles'
-                    download_subtitles(course_name,course_releasedate,chapter_index,chapter_name, vc, video_name)
+                    file_type_srt = '.srt'
+                    print ('[*] ------ Downloading subtitles')
+                    if os.path.exists(file_path + '/' + file_name + file_type_srt):
+                        print('[!]          ->subtitle file already present, skipping to next')
+                    else:                        
+                        #print 'Video-URL: "%s"' % download_url
+                        download_subtitles(file_path + '/' + file_name + file_type_srt)
+                print("")
+    print '[*] __________ Finished course "%s" __________' % course_name
                     


### PR DESCRIPTION
I used the code by duracotton to download courses. It works great for downloading new courses but it didn't have support to resume the courses with previous naming convention and folder structure.
This is my attempt to add that feature.

Sorry for one big commit (I am new to git).

1. Check presence of already downloaded videos/folders (with previous naming convention) and rename them to new
1. I extracted alphabetic names of course/chapter/video to match presence of old courses/chapter/videos
1. I have accounted for '.' and '-' in the new naming so that old coursed can be resumed.

Any suggestions/feedback?
